### PR TITLE
PRT-911: Bump new version of RDS to fix serialisation issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     
     <artifactId>dmptool-java-client</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2</version>
 
     <parent>
         <groupId>com.github.rspace-os</groupId>
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>com.github.rspace-os</groupId>
             <artifactId>rda-dmp-common-standard</artifactId>
-            <version>0.0.5</version>
+            <version>0.0.6</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Depending from the following PR:
 - rda-common: https://github.com/rspace-os/rda-dmp-common-standard/pull/6