### PR TITLE
0.4.0: switch to rspace-parent parent pom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.4.0]
+- switch parent pom from rspace-os-parent to rspace-parent (updates/changes a lot of dependencies)
+- switch to latest rda-dmp-common-standard dependency
+
 ## [0.3.0]
 - Restructuring DMP domain model
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -4,5 +4,5 @@ before_install:
   - sdk install java 17.0.2-open
   - sdk use java 17.0.2-open
   - java -version
-  - sdk install maven
+  - sdk install maven 3.9.11
   - mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <modelVersion>4.0.0</modelVersion>
     
     <artifactId>dmptool-java-client</artifactId>
-    <version>0.3.0</version>
+    <version>0.4.0</version>
     <parent>
         <groupId>com.github.rspace-os</groupId>
-        <artifactId>rspace-os-parent</artifactId>
-        <version>0.1.1</version>
+        <artifactId>rspace-parent</artifactId>
+        <version>2.1.3</version>
     </parent>
 
     <repositories>
@@ -54,6 +54,7 @@
             <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
@@ -65,18 +66,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -95,28 +84,23 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>com.jayway.jsonpath</groupId>
-          <artifactId>json-path</artifactId>
-          <version>2.8.0</version>
-          <!-- <scope>test</scope> -->
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>2.10.0</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.github.rspace-os</groupId>
             <artifactId>rda-dmp-common-standard</artifactId>
-            <version>0.1.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
+            <version>f7966a1cee</version>
         </dependency>
     </dependencies>
-
-    <properties>
-        <!-- lombok version compatible with java 17 -->
-        <lombok.version>1.18.22</lombok.version>
-    </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>rspace-parent</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4</version>
     </parent>
 
     <repositories>
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>com.github.rspace-os</groupId>
             <artifactId>rda-dmp-common-standard</artifactId>
-            <version>f7966a1cee</version>
+            <version>0.1.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- switch parent pom from 'rspace-os-parent' to 'rspace-parent'
- also use latest rda-dmp-common-standard dependency