### PR TITLE
RSDEV-1043: Applying `rda-dmp-common-standard` version `0.1.2`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     
     <artifactId>dmptool-java-client</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1</version>
     <parent>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>rspace-parent</artifactId>
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>com.github.rspace-os</groupId>
             <artifactId>rda-dmp-common-standard</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Related PR: https://github.com/rspace-os/rspace-web/pull/698