### PR TITLE
RSDEV-444: Upgrade dmptool-java-client to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.0.0]
+- Spring 6 / Hibernate 6 / Jakarta migration (RSDEV-444)
+- Upgrade to rspace-parent 3.0.0
+
 ## [0.4.0]
 - switch parent pom from rspace-os-parent to rspace-parent (updates/changes a lot of dependencies)
 - switch to latest rda-dmp-common-standard dependency

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>rspace-parent</artifactId>
-        <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>rspace-parent</artifactId>
-        <version>3.0.0</version>
+        <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
     </parent>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <modelVersion>4.0.0</modelVersion>
     
     <artifactId>dmptool-java-client</artifactId>
-    <version>0.4.0</version>
+    <version>1.0.0</version>
     <parent>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>rspace-parent</artifactId>
-        <version>2.1.4</version>
+        <version>3.0.0</version>
     </parent>
 
     <repositories>


### PR DESCRIPTION
Upgrade dmptool-java-client to 1.0.0 for Spring 6 / Jakarta migration (RSDEV-444).

Pom-only parent bump; no source changes required.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
